### PR TITLE
Indicate IDF version v5.0 needed to build CH32V003 programmer.

### DIFF
--- a/ch32v003programmer/README.md
+++ b/ch32v003programmer/README.md
@@ -9,7 +9,7 @@ Use a DevkitC. Once programmed, see ch32v003fun for more detailed instructions.
 
 You can either use a ESP32-S2 [DevkitC](https://www.digikey.com/en/products/detail/espressif-systems/ESP32-S2-DEVKITC-1-N8R2/16688755) or [this](https://github.com/cnlohr/cnhardware/tree/master/esp32s2-funprog)
 
-This is the ESP32-S2 programmer for [ch32v003fun](https://github.com/cnlohr/ch32v003fun)
+This is the ESP32-S2 programmer for [ch32v003fun](https://github.com/cnlohr/ch32v003fun) built using [ESP-IDF](https://github.com/espressif/esp-idf.git) v5.0.
 
 
 ## To just flash it without building


### PR DESCRIPTION
Closes issue #4.