### PR TITLE
don't uprintf() while interrupts disabled

### DIFF
--- a/ch32v003programmer/main/ch32v003_swio.h
+++ b/ch32v003programmer/main/ch32v003_swio.h
@@ -413,8 +413,8 @@ static int MCFReadReg32( struct SWIOState * state, uint8_t command, uint32_t * v
 
 		if( ReadBitRVSWD( t1coeff, pinmaskD, pinmaskC ) != parity )
 		{
-			uprintf( "Parity Failed\n" );
 			EnableISR();
+			uprintf( "Parity Failed\n" );
 			return -1;
 		}
 


### PR DESCRIPTION
This was causing a crash on esp32s2 on arduino framework when uprintf() was #define aliased to regular printf() 

This was due to failing to block and acquire a lock inside newlib while interrupts were disabled:

```
0x400276a2: panic_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/panic.c:397
0x4002d1b5: esp_system_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp_system/esp_system.c:136
0x400322e9: abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/abort.c:42 (discriminator 3)
0x40028ba3: lock_acquire_generic at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/locks.c:138
0x40028cdd: _lock_acquire_recursive at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/locks.c:167
0x40028d6a: __retarget_lock_acquire_recursive at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/newlib/locks.c:321
0x4012bf56: _puts_r at /builds/idf/crosstool-NG/.build/HOST-x86_64-w64-mingw32/xtensa-esp32s2-elf/src/newlib/newlib/libc/stdio/puts.c:89 (discriminator 2)
0x4012bf97: puts at /builds/idf/crosstool-NG/.build/HOST-x86_64-w64-mingw32/xtensa-esp32s2-elf/src/newlib/newlib/libc/stdio/puts.c:129
0x40025675: MCFReadReg32(SWIOState*, unsigned char, unsigned int*) at [.....]/src/ch32v003_swio.h:440
0x40083a86: InitCh32Terminal(Ch32Connection*) at [.....]/src/ch32v003_swio.h:518
```

moving the printf() outside the critical section fixes it